### PR TITLE
Detect specializations change

### DIFF
--- a/Domain.cs
+++ b/Domain.cs
@@ -1,0 +1,20 @@
+namespace Torlando.SquadTracker
+{
+    public class Player
+    {
+        public Player(string accountName, bool isSelf, string characterName, uint profession, uint currentSpecialization)
+        {
+            AccountName = accountName;
+            IsSelf = isSelf;
+            CharacterName = characterName;
+            Profession = profession;
+            CurrentSpecialization = currentSpecialization;
+        }
+
+        public string AccountName { get; private set; }
+        public bool IsSelf { get; private set; }
+        public string CharacterName { get; private set; }
+        public uint Profession { get; private set; }
+        public uint CurrentSpecialization { get; private set; }
+    }
+}

--- a/Domain.cs
+++ b/Domain.cs
@@ -1,6 +1,9 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
 namespace Torlando.SquadTracker
 {
-    public class Player
+    public class Player : INotifyPropertyChanged
     {
         public Player(string accountName, bool isSelf, string characterName, uint profession, uint currentSpecialization)
         {
@@ -8,13 +11,37 @@ namespace Torlando.SquadTracker
             IsSelf = isSelf;
             CharacterName = characterName;
             Profession = profession;
-            CurrentSpecialization = currentSpecialization;
+
+            _currentSpecialization = currentSpecialization;
         }
 
         public string AccountName { get; private set; }
         public bool IsSelf { get; private set; }
         public string CharacterName { get; private set; }
         public uint Profession { get; private set; }
-        public uint CurrentSpecialization { get; private set; }
+
+        public uint CurrentSpecialization
+        {
+            get => _currentSpecialization;
+            set
+            {
+                _currentSpecialization = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private uint _currentSpecialization;
+
+        #region INotifyPropertyChanged
+
+        /// <inheritdoc cref="INotifyPropertyChanged.PropertyChanged"/>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void OnPropertyChanged([CallerMemberName] string name = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+
+        #endregion
     }
 }

--- a/Module.cs
+++ b/Module.cs
@@ -107,11 +107,10 @@ namespace Blish_HUD_Module1
             base.OnModuleLoaded(e);
         }
 
-        private async void PlayerAddedEvent(CommonFields.Player player)
+        private void PlayerAddedEvent(CommonFields.Player player)
         {
             _arcPlayers = (ConcurrentDictionary<string, CommonFields.Player>)GameService.ArcDps.Common.PlayersInSquad;
-            var icon = GetSpecializationIcon(player);
-            await _playerCollection.AddPlayer(player, icon, _customRoles);
+            _playerCollection.AddPlayer(player, GetSpecializationIcon, _customRoles);
             _squadMembersPanel.BasicTooltipText = "";
         }
 
@@ -288,22 +287,22 @@ namespace Blish_HUD_Module1
             // All static members must be manually unset
         }
 
-        private async Task<Blish_HUD.Content.AsyncTexture2D> GetSpecializationIcon(CommonFields.Player player)
+        private async Task<Blish_HUD.Content.AsyncTexture2D> GetSpecializationIcon(uint professionCode, uint specializationCode)
         {
             var connection = new Gw2Sharp.Connection();
             using var client = new Gw2Sharp.Gw2Client(connection);
             var webApiClient = client.WebApi.V2;
             var specializationClient = webApiClient.Specializations;
             var professionsClient = webApiClient.Professions;
-            if (player.Elite == 0)
+            if (specializationCode == 0)
             {
-                int playerProfession = (int) player.Profession;
+                int playerProfession = (int)professionCode;
                 var allProffesions = await professionsClient.AllAsync();
                 var proffessionId = allProffesions[playerProfession - 1].Id;
                 var profession = await professionsClient.GetAsync(proffessionId);
                 return GameService.Content.GetRenderServiceTexture(profession.IconBig);
             }
-            var eliteSpec = await specializationClient.GetAsync((int)player.Elite);
+            var eliteSpec = await specializationClient.GetAsync((int)specializationCode);
             return GameService.Content.GetRenderServiceTexture(eliteSpec.ProfessionIconBig);
         }
 

--- a/Module.cs
+++ b/Module.cs
@@ -1,4 +1,5 @@
-﻿using Blish_HUD;
+using Blish_HUD;
+using Blish_HUD.ArcDps;
 using Blish_HUD.ArcDps.Common;
 using Blish_HUD.Controls;
 using Blish_HUD.Modules;
@@ -90,6 +91,7 @@ namespace Blish_HUD_Module1
             GameService.ArcDps.Common.Activate();
             GameService.ArcDps.Common.PlayerAdded += PlayerAddedEvent;
             GameService.ArcDps.Common.PlayerRemoved += PlayerRemovedEvent;
+            GameService.ArcDps.RawCombatEvent += RawCombatEvent;
             _playerCollection = new PlayerCollection(_arcPlayers, _squadMembersPanel, _formerSquadMembersPanel);
             var predefinedRoles = new List<Role>
             {
@@ -111,6 +113,12 @@ namespace Blish_HUD_Module1
             var icon = GetSpecializationIcon(player);
             await _playerCollection.AddPlayer(player, icon, _customRoles);
             _squadMembersPanel.BasicTooltipText = "";
+        }
+
+        private void RawCombatEvent(object sender, RawCombatEventArgs e)
+        {
+            var ag = e.CombatEvent.Src;
+            _playerCollection.UpdatePlayerSpecialization(ag.Name, ag.Elite);
         }
 
         private void PlayerRemovedEvent(CommonFields.Player player)

--- a/Module.cs
+++ b/Module.cs
@@ -1,6 +1,7 @@
-using Blish_HUD;
+﻿using Blish_HUD;
 using Blish_HUD.ArcDps;
 using Blish_HUD.ArcDps.Common;
+using Blish_HUD.Content;
 using Blish_HUD.Controls;
 using Blish_HUD.Modules;
 using Blish_HUD.Modules.Managers;
@@ -12,6 +13,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel.Composition;
+using System.Linq;
 using System.Threading.Tasks;
 using Torlando.SquadTracker;
 
@@ -30,6 +32,13 @@ namespace Blish_HUD_Module1
         internal ContentsManager ContentsManager => this.ModuleParameters.ContentsManager;
         internal DirectoriesManager DirectoriesManager => this.ModuleParameters.DirectoriesManager;
         internal Gw2ApiManager Gw2ApiManager => this.ModuleParameters.Gw2ApiManager;
+        #endregion
+
+        #region Textures
+
+        private IReadOnlyDictionary<uint, AsyncTexture2D> _professionIcons;
+        private IReadOnlyDictionary<uint, AsyncTexture2D> _specializationIcons;
+
         #endregion
 
         #region Controls
@@ -78,6 +87,30 @@ namespace Blish_HUD_Module1
         protected override async Task LoadAsync()
         {
             _tabPanel = BuildPanel(GameService.Overlay.BlishHudWindow.ContentRegion);
+             await LoadSpecializationIconsAsync();
+        }
+
+        private async Task LoadSpecializationIconsAsync()
+        {
+            var connection = new Gw2Sharp.Connection();
+            using var client = new Gw2Sharp.Gw2Client(connection);
+            var webApiClient = client.WebApi.V2;
+
+            var professionsClient = webApiClient.Professions;
+            var professions = await professionsClient.AllAsync();
+
+            _professionIcons = professions.ToDictionary(
+                keySelector: (profession) => (uint)profession.Code,
+                (profession) => GameService.Content.GetRenderServiceTexture(profession.IconBig)
+            );
+
+            var specializationClient = webApiClient.Specializations;
+            var eliteSpecs = await specializationClient.ManyAsync(EliteSpecializationCodes);
+
+            _specializationIcons = eliteSpecs.ToDictionary(
+                keySelector: (spec) => (uint)spec.Id,
+                (spec) => GameService.Content.GetRenderServiceTexture(spec.ProfessionIconBig)
+            );
         }
 
         /// <summary>
@@ -287,23 +320,14 @@ namespace Blish_HUD_Module1
             // All static members must be manually unset
         }
 
-        private async Task<Blish_HUD.Content.AsyncTexture2D> GetSpecializationIcon(uint professionCode, uint specializationCode)
+        private AsyncTexture2D GetSpecializationIcon(uint professionCode, uint specializationCode)
         {
-            var connection = new Gw2Sharp.Connection();
-            using var client = new Gw2Sharp.Gw2Client(connection);
-            var webApiClient = client.WebApi.V2;
-            var specializationClient = webApiClient.Specializations;
-            var professionsClient = webApiClient.Professions;
             if (specializationCode == 0)
             {
-                int playerProfession = (int)professionCode;
-                var allProffesions = await professionsClient.AllAsync();
-                var proffessionId = allProffesions[playerProfession - 1].Id;
-                var profession = await professionsClient.GetAsync(proffessionId);
-                return GameService.Content.GetRenderServiceTexture(profession.IconBig);
+                return _professionIcons[professionCode];
             }
-            var eliteSpec = await specializationClient.GetAsync((int)specializationCode);
-            return GameService.Content.GetRenderServiceTexture(eliteSpec.ProfessionIconBig);
+
+            return _specializationIcons[specializationCode];
         }
 
 
@@ -381,6 +405,45 @@ namespace Blish_HUD_Module1
 
             };
         }
+
+        private static readonly IReadOnlyCollection<int> EliteSpecializationCodes = new []
+        {
+            18, // Berserker
+            61, // Spellbreaker
+            //68, // Bladesworn
+
+            27, // Dragonhunter
+            62, // Firebrand
+            //65, // Willbender
+
+            52, // Herald
+            63, // Renegade
+            //69, // Vindicator
+
+            5, // Druid
+            55, // Soulbeast
+            //72, // Untamed
+
+            7, // Daredevil
+            58, // Deadeye
+            //71, // Specter
+
+            43, // Scrapper
+            57, // Holosmith
+            //70, // Mechanist
+
+            34, // Reaper
+            60, // Scourge
+            //64, // Harbinger
+
+            48, // Tempest
+            56, // Weaver
+            //67, // Catalyst
+
+            40, // Chronomancer
+            59, // Mirage
+            //66, // Virtuoso
+        };
     }
 
 }

--- a/PlayerCollection.cs
+++ b/PlayerCollection.cs
@@ -48,6 +48,15 @@ namespace Torlando.SquadTracker
             _playerDisplays.Add(new PlayerDisplay(_activePlayerPanel, _formerPlayerPanel, player, await icon, availableRoles));
         }
 
+        public void UpdatePlayerSpecialization(string characterName, uint newSpec)
+        {
+            var hasPlayer = _players.TryGetValue(characterName, out var player);
+            if (!hasPlayer) return;
+            if (player.CurrentSpecialization == newSpec) return;
+
+            player.CurrentSpecialization = newSpec;
+        }
+
         public void RemovePlayerFromActivePanel(CommonFields.Player arcPlayer)
         {
             //if (arcPlayer.Self && !_players.Any(x => x.IsSelf)) return; //Don't remove yourself, unless you changed characters

--- a/PlayerCollection.cs
+++ b/PlayerCollection.cs
@@ -1,4 +1,4 @@
-using Blish_HUD.ArcDps.Common;
+﻿using Blish_HUD.ArcDps.Common;
 using Blish_HUD.Content;
 using Blish_HUD.Controls;
 using Microsoft.Xna.Framework;

--- a/PlayerCollection.cs
+++ b/PlayerCollection.cs
@@ -11,7 +11,7 @@ namespace Torlando.SquadTracker
 {
     public class PlayerCollection
     {
-        private ObservableCollection<Player> _players;
+        private ObservableCollection<PlayerDisplay> _playerDisplays;
         private ConcurrentDictionary<string, CommonFields.Player> _arcPlayersInSquad;
 
         private Panel _activePlayerPanel;
@@ -19,7 +19,7 @@ namespace Torlando.SquadTracker
 
         public PlayerCollection(ConcurrentDictionary<string, CommonFields.Player> arcPlayersInSquad, Panel activePlayerPanel, Panel formerPlayerPanel)
         {
-            _players = new ObservableCollection<Player>();
+            _playerDisplays = new ObservableCollection<PlayerDisplay>();
             _arcPlayersInSquad = arcPlayersInSquad;
             _activePlayerPanel = activePlayerPanel;
             _formerPlayerPanel = formerPlayerPanel;
@@ -27,18 +27,18 @@ namespace Torlando.SquadTracker
 
         public async Task AddPlayer(CommonFields.Player arcPlayer, Task<Blish_HUD.Content.AsyncTexture2D> icon, ObservableCollection<string> availableRoles)
         {
-            if (_players.Any(x => x.CharacterName.Equals(arcPlayer.CharacterName)))
+            if (_playerDisplays.Any(x => x.CharacterName.Equals(arcPlayer.CharacterName)))
             {
                 // Move from former players if player rejoined
-                var player = GetPlayer(arcPlayer);
-                if (player?.IsFormerSquadMember ?? false)
+                var playerDisplay = GetPlayer(arcPlayer);
+                if (playerDisplay?.IsFormerSquadMember ?? false)
                 {
-                    player.MoveFormerSquadMemberToActivePanel();
+                    playerDisplay.MoveFormerSquadMemberToActivePanel();
                 }
                 //Don't add duplicate player
                 return;
             }
-            _players.Add(new Player(_activePlayerPanel, _formerPlayerPanel, arcPlayer, await icon, availableRoles));
+            _playerDisplays.Add(new PlayerDisplay(_activePlayerPanel, _formerPlayerPanel, arcPlayer, await icon, availableRoles));
         }
 
         public void RemovePlayerFromActivePanel(CommonFields.Player arcPlayer)
@@ -50,7 +50,7 @@ namespace Torlando.SquadTracker
 
         public void ClearFormerPlayers()
         {
-            foreach (var player in _players)
+            foreach (var player in _playerDisplays)
             {
                 if (player.IsFormerSquadMember)
                     player.DisposeDetailsButton(); //todo - test this
@@ -62,13 +62,13 @@ namespace Torlando.SquadTracker
             return _arcPlayersInSquad.First(x => x.Value.CharacterName.Equals(characterName)).Value;
         }
 
-        private Player GetPlayer(CommonFields.Player arcPlayer)
+        private PlayerDisplay GetPlayer(CommonFields.Player arcPlayer)
         {
-            return _players.First(x => x.CharacterName.Equals(arcPlayer.CharacterName));
+            return _playerDisplays.First(x => x.CharacterName.Equals(arcPlayer.CharacterName));
         }
     }
 
-    public class Player
+    public class PlayerDisplay
     {
         #region Data
         private CommonFields.Player _arcPlayer;
@@ -88,7 +88,7 @@ namespace Torlando.SquadTracker
         public string CharacterName => _arcPlayer.CharacterName;
         public bool IsFormerSquadMember => _detailsButton.Parent?.Equals(_formerPlayerPanel) ?? false;
         public bool IsSelf => _arcPlayer.Self;
-        public Player(Panel activePlayerPanel, 
+        public PlayerDisplay(Panel activePlayerPanel,
             Panel formerPlayerPanel, CommonFields.Player arcPlayer, Blish_HUD.Content.AsyncTexture2D icon, ObservableCollection<string> availableRoles)
         {
             _activePlayerPanel = activePlayerPanel;

--- a/SquadTracker.csproj
+++ b/SquadTracker.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -132,6 +132,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Domain.cs" />
     <Compile Include="Module.cs" />
     <Compile Include="PlayerCollection.cs" />
     <Compile Include="Role.cs" />


### PR DESCRIPTION
This PR adds code to detect when a player changed specialization. In these cases, the icon of the player changes to the new specialization, with a slight delay.