### PR TITLE
Fix a bug where the elite spec icon no longer updated. 

### DIFF
--- a/Domain.cs
+++ b/Domain.cs
@@ -32,24 +32,6 @@ namespace Torlando.SquadTracker
         public uint Profession { get; private set; }
         public bool HasChangedCharacters => PreviouslyPlayedCharacters?.Count > 0;
         public HashSet<Player> PreviouslyPlayedCharacters { get; set; }
-        public bool TryGetPlayedCharacterByName(string characterName, out Player player)
-        {
-            if (CharacterName.Equals(characterName))
-            {
-                player = this;
-                return true;
-            }
-            foreach (var character in PreviouslyPlayedCharacters)
-            {
-                if (characterName.Equals(character.CharacterName))
-                {
-                    player = character;
-                    return true;
-                }
-            }
-            player = null;
-            return false;
-        }
 
         public uint CurrentSpecialization
         {

--- a/Domain.cs
+++ b/Domain.cs
@@ -32,6 +32,24 @@ namespace Torlando.SquadTracker
         public uint Profession { get; private set; }
         public bool HasChangedCharacters => PreviouslyPlayedCharacters?.Count > 0;
         public HashSet<Player> PreviouslyPlayedCharacters { get; set; }
+        public bool TryGetPlayedCharacterByName(string characterName, out Player player)
+        {
+            if (CharacterName.Equals(characterName))
+            {
+                player = this;
+                return true;
+            }
+            foreach (var character in PreviouslyPlayedCharacters)
+            {
+                if (characterName.Equals(character.CharacterName))
+                {
+                    player = character;
+                    return true;
+                }
+            }
+            player = null;
+            return false;
+        }
 
         public uint CurrentSpecialization
         {

--- a/PlayerCollection.cs
+++ b/PlayerCollection.cs
@@ -60,9 +60,10 @@ namespace Torlando.SquadTracker
 
         public void UpdatePlayerSpecialization(string characterName, uint newSpec)
         {
-            var hasPlayer = _players.TryGetValue(characterName, out var player);
+            Player player = null;
+            var hasPlayer = _players.Values.ToList().Any(x => x.TryGetPlayedCharacterByName(characterName, out player));
             if (!hasPlayer) return;
-            if (player.CurrentSpecialization == newSpec) return;
+            if (player?.CurrentSpecialization == newSpec) return;
 
             player.CurrentSpecialization = newSpec;
         }

--- a/PlayerCollection.cs
+++ b/PlayerCollection.cs
@@ -65,7 +65,7 @@ namespace Torlando.SquadTracker
             );
             var player = allPlayers.FirstOrDefault(player => player.CharacterName == characterName);
             if (player == null) return;
-            if (player?.CurrentSpecialization == newSpec) return;
+            if (player.CurrentSpecialization == newSpec) return;
 
             player.CurrentSpecialization = newSpec;
         }

--- a/PlayerCollection.cs
+++ b/PlayerCollection.cs
@@ -60,9 +60,11 @@ namespace Torlando.SquadTracker
 
         public void UpdatePlayerSpecialization(string characterName, uint newSpec)
         {
-            Player player = null;
-            var hasPlayer = _players.Values.ToList().Any(x => x.TryGetPlayedCharacterByName(characterName, out player));
-            if (!hasPlayer) return;
+            var allPlayers = _players.Values.Concat(
+                _players.ToList().SelectMany(player => player.Value.PreviouslyPlayedCharacters)
+            );
+            var player = allPlayers.FirstOrDefault(player => player.CharacterName == characterName);
+            if (player == null) return;
             if (player?.CurrentSpecialization == newSpec) return;
 
             player.CurrentSpecialization = newSpec;


### PR DESCRIPTION
Was due to the _players dictionary now having a key of account name instead of character name. Also include possible edge case where the player changed characters