### PR TITLE
Empty sequence crash

### DIFF
--- a/PlayerCollection.cs
+++ b/PlayerCollection.cs
@@ -85,6 +85,7 @@ namespace Torlando.SquadTracker
                 if(TryGetPlayer(arcPlayer, out var playerToRemove))
                 {
                     playerToRemove.RemovePlayerFromActivePanel();
+                    return;
                 }
                 else
                 {

--- a/PlayerCollection.cs
+++ b/PlayerCollection.cs
@@ -1,4 +1,5 @@
-﻿using Blish_HUD.ArcDps.Common;
+﻿using Blish_HUD;
+using Blish_HUD.ArcDps.Common;
 using Blish_HUD.Content;
 using Blish_HUD.Controls;
 using Microsoft.Xna.Framework;
@@ -10,6 +11,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Text;
+using System.Threading;
 
 namespace Torlando.SquadTracker
 {
@@ -21,6 +23,8 @@ namespace Torlando.SquadTracker
 
         private Panel _activePlayerPanel;
         private Panel _formerPlayerPanel;
+
+        private static readonly Logger Logger = Logger.GetLogger<Module>();
 
         public PlayerCollection(ConcurrentDictionary<string, CommonFields.Player> arcPlayersInSquad, Panel activePlayerPanel, Panel formerPlayerPanel)
         {
@@ -35,7 +39,7 @@ namespace Torlando.SquadTracker
         {
             if (_players.TryGetValue(arcPlayer.AccountName, out var existingPlayer))
             {
-                var playerDisplay = GetPlayer(arcPlayer);
+                _ = TryGetPlayer(arcPlayer, out var playerDisplay);
 
                 // Move from former players if player rejoined
                 if (playerDisplay?.IsFormerSquadMember ?? false)
@@ -75,8 +79,19 @@ namespace Torlando.SquadTracker
         public void RemovePlayerFromActivePanel(CommonFields.Player arcPlayer)
         {
             //if (arcPlayer.Self && !_players.Any(x => x.IsSelf)) return; //Don't remove yourself, unless you changed characters
-            var playerToRemove = GetPlayer(arcPlayer);
-            playerToRemove.RemovePlayerFromActivePanel();
+            var retries = 3;
+            while(retries > 0)
+            {
+                if(TryGetPlayer(arcPlayer, out var playerToRemove))
+                {
+                    playerToRemove.RemovePlayerFromActivePanel();
+                }
+                else
+                {
+                    Thread.Sleep(3000);
+                    retries--;
+                }
+            }
         }
 
         public void ClearFormerPlayers()
@@ -93,9 +108,19 @@ namespace Torlando.SquadTracker
             return _arcPlayersInSquad.First(x => x.Value.CharacterName.Equals(characterName)).Value;
         }
 
-        private PlayerDisplay GetPlayer(CommonFields.Player arcPlayer)
+        private bool TryGetPlayer(CommonFields.Player arcPlayer, out PlayerDisplay playerDisplay)
         {
-            return _playerDisplays.First(x => x.AccountName.Equals(arcPlayer.AccountName));
+            try
+            {
+                playerDisplay = _playerDisplays.First(x => x.AccountName.Equals(arcPlayer.AccountName));
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Caught exception while trying to get PlayerDisplay to remove from Current Squad Members: {ex}");
+                playerDisplay = null;
+                return false;
+            }
         }
     }
 

--- a/PlayerCollection.cs
+++ b/PlayerCollection.cs
@@ -1,5 +1,4 @@
-﻿using Blish_HUD;
-using Blish_HUD.ArcDps.Common;
+﻿using Blish_HUD.ArcDps.Common;
 using Blish_HUD.Content;
 using Blish_HUD.Controls;
 using Microsoft.Xna.Framework;
@@ -23,8 +22,6 @@ namespace Torlando.SquadTracker
 
         private Panel _activePlayerPanel;
         private Panel _formerPlayerPanel;
-
-        private static readonly Logger Logger = Logger.GetLogger<Module>();
 
         public PlayerCollection(ConcurrentDictionary<string, CommonFields.Player> arcPlayersInSquad, Panel activePlayerPanel, Panel formerPlayerPanel)
         {
@@ -111,17 +108,9 @@ namespace Torlando.SquadTracker
 
         private bool TryGetPlayer(CommonFields.Player arcPlayer, out PlayerDisplay playerDisplay)
         {
-            try
-            {
-                playerDisplay = _playerDisplays.First(x => x.AccountName.Equals(arcPlayer.AccountName));
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Logger.Error($"Caught exception while trying to get PlayerDisplay to remove from Current Squad Members: {ex}");
-                playerDisplay = null;
-                return false;
-            }
+            
+            playerDisplay = _playerDisplays.FirstOrDefault(x => x.AccountName.Equals(arcPlayer.AccountName));
+            return playerDisplay != null;
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,75 @@
 # SquadTracker
 
-BlishHUD module for tracking squad members and their roles.
+A [BlishHUD](https://blishhud.com/) module for tracking squad members and their roles. 
+
+## Features
+
+* Automatically detect party members who enter/leave your current instance
+
+* List the known characters of each player
+
+* Keep track of the players who left your instance, and their roles
+
+* Assign up to two roles to each party member
+
+* Define your own custom roles, with custom icons (WIP)
+
+## Installation
+### Prerequisites 
+Note that this module requires [ArcDPS](https://www.deltaconnected.com/arcdps/) and the [ArcDPS Blish HUD Integration](https://github.com/blish-hud/arcdps-bhud) to function. Both of these can be downloaded manually or via the [Guild Wars 2 Unofficial Addon Manager](https://github.com/gw2-addon-loader/GW2-Addon-Manager). 
+### Recommended
+Look for SquadTracker in the [BlishHUD Module Package Manager](https://blishhud.com/docs/user/installing-modules).
+
+### Manual (not recommended)
+1. Download the lastest version SquadTracker.bhm from the [releases](https://github.com/tcwatson/SquadTracker/releases) page.
+2. Place SquadTracker.bhm in your BlishHUD modules folder, usually located at `C:\Users\YourUserName\Documents\Guild Wars 2\addons\blishhud\modules`
+
+## Usage
+After installing and enabling the module from Blish HUD, find the tab that looks like a commander tag in the main Blish HUD Window. 
+
+There are two panels in the menu - Squad Members and Squad Roles. 
+
+The Squad Members panel shows current and former squad/party members, along with roles that you have assigned to them. In order for players to appear as Current Squad Members, they must be in the same map instance as you. If they leave your map, they will be moved to the Former Squad Members panel (for now - we're working on a solution for that). As players enter/exit your squad or instance, the roles you assign to them will be retained.
+
+If a player changes characters, their previous characters are displayed in a tooltip when mousing over their box. 
+
+The Squad Roles panel allows you to add your own custom roles. At the top, type in the name of the role you want, and click Add. These roles will be saved to a file on your hard drive, and will be loaded up the next time you play. Once you've added a new role, it should be selectable from the dropdowns on the Squad Members panel.
+
+### Adding custom icons (WIP)
+If you are comfortable editing a JSON file, you may add custom icons to the roles you define. The file is (usually) saved at `C:\Users\YourUserName\Documents\Guild Wars 2\addons\blishhud\squadtracker\roles.json`. Roles you add through the SquadTracker UI will appear in this JSON file. For example, here is the contents of a JSON file with two custom roles added - Tank and Banners. 
+``` 
+[
+    {
+        "Name": "Quickness",
+        "IconPath": "icons\\quickness.png"
+    },
+    {
+        "Name": "Alacrity",
+        "IconPath": "icons\\alacrity.png"
+    },
+    {
+        "Name": "Heal",
+        "IconPath": "icons\\regeneration.png"
+    },
+    {
+        "Name": "Power DPS",
+        "IconPath": "icons\\power.png"
+    },
+    {
+        "Name": "Condi DPS",
+        "IconPath": "icons\\Condition_Damage.png"
+    },
+    {
+        "Name": "Tank",
+        "IconPath": "C:\\Users\\YourUserName\\Documents\\Guild Wars 2\\addons\\blishhud\\squadtracker\\Toughness.png"
+    },
+    {
+        "Name": "Banners",
+        "IconPath": ""
+    }
+]
+```
+In this example, the `Tank` role has been manually edited to fill in the `IconPath` value with the full path to the icon to use. The `Banners` role has no icon. Note that you must use a double backslash `\\` in the full path for your icon image. The location of the image doesn't matter, so long as you give the full path here. 
+## Known Issues
+
+## Contributing


### PR DESCRIPTION
Potential fix for #26. Wasn't able to reproduce the bug, but looking through the code, this could avoid a potential race condition, in which a player leaves the squad or map before the `PlayerDisplay` has been added to the `_playerDisplays`. 