### PR TITLE
feat: add a class to detect if ArcDPS has timed out or not

### DIFF
--- a/SquadTracker/ArcDpsTimeoutChecker.cs
+++ b/SquadTracker/ArcDpsTimeoutChecker.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using Blish_HUD;
+using Blish_HUD.ArcDps;
+using Microsoft.Xna.Framework;
+
+namespace Torlando.SquadTracker
+{
+    /// <summary>
+    /// Class used to detect whether ArcDPS is still sending events or not.
+    /// If, while in combat, no events have been received for 1 minute, this class will consider ArcDPS as timed out.
+    /// </summary>
+    public class ArcDpsTimeoutChecker
+    {
+        /// <summary>
+        /// Raised when no event have been received from ArcDPS for too long.
+        /// </summary>
+        public event EventHandler ArcDpsTimedOut;
+
+        // To adjust as needed, eventually put it in settings?
+        private const double TIMEOUT_DELAY_MILLISECONDS = 60_000;
+
+        private readonly ArcDpsService _arcDpsService;
+        private readonly OverlayService _overlayService;
+        private readonly Gw2MumbleService _gw2MumbleService;
+
+        /// <summary>
+        /// <c>true</c> if the instance is currently checking, <c>false</c> otherwise.
+        /// </summary>
+        public bool IsEnabled { get; private set; }
+
+        private double? _lastEventTime = null;
+
+        public ArcDpsTimeoutChecker(ArcDpsService arcDpsService, OverlayService overlayService, Gw2MumbleService gw2MumbleService)
+        {
+            _arcDpsService = arcDpsService;
+            _overlayService = overlayService;
+            _gw2MumbleService = gw2MumbleService;
+
+            _arcDpsService.RawCombatEvent += OnCombatEvent;
+            _gw2MumbleService.PlayerCharacter.IsInCombatChanged += IsInCombatChanged;
+        }
+
+        /// <summary>
+        /// Start checking if ArcDPS has timed out or not.
+        /// </summary>
+        public void Enable()
+        {
+            this.IsEnabled = true;
+
+            _lastEventTime = _gw2MumbleService.PlayerCharacter.IsInCombat switch
+            {
+                true => _overlayService.CurrentGameTime.TotalGameTime.TotalMilliseconds,
+                false => null,
+            };
+        }
+
+        /// <summary>
+        /// To call during the update loop to check if ArcDPS has timed out or not.
+        /// </summary>
+        /// <param name="gameTime">The current step of the game.</param>
+        public void Check(GameTime gameTime)
+        {
+            if (this.IsEnabled == false) return;
+            if (_lastEventTime == null) return;
+
+            var currentTime = gameTime.TotalGameTime.TotalMilliseconds;
+
+            if (currentTime - _lastEventTime > TIMEOUT_DELAY_MILLISECONDS) {
+                this.IsEnabled = false;
+                ArcDpsTimedOut?.Invoke(this, new EventArgs());
+            }
+        }
+
+        private void OnCombatEvent(object sender, RawCombatEventArgs e)
+        {
+            if (this.IsEnabled == false) return;
+            if (_lastEventTime == null) return;
+
+            _lastEventTime = _overlayService.CurrentGameTime.TotalGameTime.TotalMilliseconds;
+        }
+
+        private void IsInCombatChanged(object sender, ValueEventArgs<bool> e)
+        {
+            if (this.IsEnabled == false) return;
+
+            _lastEventTime = e.Value switch
+            {
+                true => _overlayService.CurrentGameTime.TotalGameTime.TotalMilliseconds,
+                false => null,
+            };
+        }
+    }
+}

--- a/SquadTracker/Module.cs
+++ b/SquadTracker/Module.cs
@@ -23,6 +23,7 @@ namespace Torlando.SquadTracker
 
         private static readonly Logger Logger = Logger.GetLogger<Module>();
 
+        private ArcDpsTimeoutChecker _arcDpsTimeoutChecker;
         private PlayersManager _playersManager;
         private SquadManager _squadManager;
         private PlayerIconsManager _playerIconsManager;
@@ -138,8 +139,16 @@ namespace Torlando.SquadTracker
                 },
                 name: "Squad Tracker Tab"
             );
-            
+
+            _arcDpsTimeoutChecker = new ArcDpsTimeoutChecker(GameService.ArcDps, GameService.Overlay, GameService.Gw2Mumble);
+            _arcDpsTimeoutChecker.ArcDpsTimedOut += (o, e) =>
+            {
+                Logger.Debug("Lost connexion to ArcDPS… Retrying.");
+                _arcDpsTimeoutChecker.Enable();
+            };
+
             GameService.ArcDps.Common.Activate();
+            _arcDpsTimeoutChecker.Enable();
 
             // Base handler must be called
             base.OnModuleLoaded(e);
@@ -151,7 +160,7 @@ namespace Torlando.SquadTracker
 
         protected override void Update(GameTime gameTime)
         {
-
+            _arcDpsTimeoutChecker.Check(gameTime);
         }
 
         // happens when you disable the module

--- a/SquadTracker/SquadTracker.csproj
+++ b/SquadTracker/SquadTracker.csproj
@@ -77,6 +77,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ArcDpsTimeoutChecker.cs" />
     <Compile Include="Constants\Placeholder.cs" />
     <Compile Include="Helpers\IconHelper.cs" />
     <Compile Include="PlayersManager.cs" />


### PR DESCRIPTION
This commit adds a class detecting if ArcDPS has timed out or not.
It measures the interval of time since the last ArcDPS event, and declares a
time out after 60 seconds.

After the time out, the counter is reset, and a message is logged.

To prevent it from triggering too often when idle, it only counts when the
player is in combat. The only way I've managed to trigger a false positive
is to have a totally empty build on an armorless (because of 6th rune bonus)
character, and being idle after hitting a training golem.

I think it should be okay, we'll see with usage!